### PR TITLE
Load all dependencies from main application

### DIFF
--- a/mrblib/context.rb
+++ b/mrblib/context.rb
@@ -36,7 +36,7 @@ class Context
 
   def self.ruby(app, platform, json, exec = true)
     unless exec
-      $LOAD_PATH = ["./#{app}"]
+      $LOAD_PATH = ['./main', "./#{app}"]
 
       if Object.const_defined? :Platform
         Platform.boot if Platform.respond_to?(:boot)


### PR DESCRIPTION
For now we will need to load all application dependencies from main in order to make an update package smaller