### PR TITLE
feature/logcat

### DIFF
--- a/include/mruby/ext/context.h
+++ b/include/mruby/ext/context.h
@@ -11,16 +11,32 @@
 #ifndef _CONTEXT_H_INCLUDED_
 #define _CONTEXT_H_INCLUDED_
 
+#ifdef _ENG_DEBUG_ /* TODO: remove?! */
+#include "libeng/engine.h"
+#endif /* #ifdef _ENG_DEBUG_ */
+
+#if defined ENG_TRACE && !defined TRACE
+#define TRACE(...) ENG_TRACE(__VA_ARGS__)
+#else
 #ifndef TRACE
 #define TRACE(...)
 #endif /* #ifndef TRACE */
+#endif /* #if defined ENG_TRACE && !defined TRACE */
 
+#if defined ENG_TRACE_FUNCTION && !defined TRACE_FUNCTION
+#define TRACE_FUNCTION(...) ENG_TRACE_FUNCTION(__VA_ARGS__)
+#else
 #ifndef TRACE_FUNCTION
 #define TRACE_FUNCTION(...)
 #endif /* #ifndef TRACE_FUNCTION */
+#endif /* #if defined ENG_TRACE_FUNCTION && !defined TRACE_FUNCTION */
 
+#if defined ENG_TRACE_INIT && !defined TRACE_INIT
+#define TRACE_INIT(...) ENG_TRACE_INIT(__VA_ARGS__)
+#else
 #ifndef TRACE_INIT
 #define TRACE_INIT(...)
 #endif /* #ifndef TRACE_INIT */
+#endif /* #if defined ENG_TRACE_INIT && !defined TRACE_INIT */
 
 #endif /* _CONTEXT_H_INCLUDED_ */

--- a/include/mruby/ext/context_log.h
+++ b/include/mruby/ext/context_log.h
@@ -6,6 +6,8 @@
 extern "C" {
 #endif
 
+#include "context.h"
+
 void ContextLog(mrb_state *mrb, int severity_level, const char *format, ...);
 void ContextLogFile(const char *format, ...);
 


### PR DESCRIPTION
This PR is an extension of the [PR #54](https://github.com/cloudwalk/robot_rock/pull/54) from robot_rock. It is required to enable macros `TRACE` and `TRACE_FUNCTION` to those who want to use the LOGCAT feature in debug builds.